### PR TITLE
Add ability to delete remote files

### DIFF
--- a/lib/upload.ex
+++ b/lib/upload.ex
@@ -79,6 +79,12 @@ defmodule Upload do
   def transfer(%__MODULE__{} = upload), do: adapter().transfer(upload)
 
   @doc """
+  Deletes the file where it is stored.
+  """
+  @spec delete(Upload.t()) :: :ok | {:error, String.t()}
+  def delete(%__MODULE__{} = upload), do: adapter().delete(upload)
+
+  @doc """
   Converts a `Plug.Upload` to an `Upload`.
 
   ## Examples
@@ -157,7 +163,7 @@ defmodule Upload do
   """
   @spec generate_key(String.t(), [{:prefix, list}]) :: String.t()
   def generate_key(filename, opts \\ []) when is_binary(filename) do
-    if Keyword.get(opts, :generate_key) do
+    if Keyword.get(opts, :generate_key, true) do
       uuid = UUID.uuid4(:hex)
       ext = get_extension(filename)
 

--- a/lib/upload/adapter.ex
+++ b/lib/upload/adapter.ex
@@ -12,4 +12,5 @@ defmodule Upload.Adapter do
   @callback get_url(String.t()) :: String.t()
   @callback get_signed_url(String.t(), Keyword.t()) :: {:ok, String.t()} | {:error, String.t()}
   @callback transfer(Upload.t()) :: {:ok, Upload.transferred()} | {:error, String.t()}
+  @callback delete(Upload.t()) :: :ok | {:error, String.t()}
 end

--- a/lib/upload/adapters/fake.ex
+++ b/lib/upload/adapters/fake.ex
@@ -17,4 +17,9 @@ defmodule Upload.Adapters.Fake do
   def transfer(%Upload{} = upload) do
     {:ok, %Upload{upload | status: :transferred}}
   end
+
+  @impl true
+  def delete(%Upload{} = _upload) do
+    :ok
+  end
 end

--- a/lib/upload/adapters/local.ex
+++ b/lib/upload/adapters/local.ex
@@ -59,6 +59,16 @@ defmodule Upload.Adapters.Local do
     end
   end
 
+  @impl true
+  def delete(%Upload{key: key}) do
+    filename = Path.join(storage_path(), key)
+
+    case File.rm(filename) do
+      :ok -> :ok
+      {:error, posix_error} -> {:error, inspect(posix_error)}
+    end
+  end
+
   defp join_url(a, b) do
     String.trim_trailing(a, "/") <> "/" <> String.trim_leading(b, "/")
   end

--- a/lib/upload/adapters/s3.ex
+++ b/lib/upload/adapters/s3.ex
@@ -80,7 +80,7 @@ if Code.ensure_loaded?(ExAws.S3) do
           :ok
 
         {:error, reason} ->
-          {:error, "failed to delete file: #{reason}"}
+          {:error, "failed to delete file: #{inspect(reason)}"}
       end
     end
 

--- a/lib/upload/adapters/s3.ex
+++ b/lib/upload/adapters/s3.ex
@@ -73,10 +73,27 @@ if Code.ensure_loaded?(ExAws.S3) do
       end
     end
 
+    @impl true
+    def delete(%Upload{key: key}) do
+      case delete_object(key) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          {:error, "failed to delete file: #{reason}"}
+      end
+    end
+
     defp put_object(key, path) do
       path
       |> ExAws.S3.Upload.stream_file()
       |> ExAws.S3.upload(bucket(), key)
+      |> ExAws.request()
+    end
+
+    def delete_object(key) do
+      bucket()
+      |> ExAws.S3.delete_object(key)
       |> ExAws.request()
     end
   end

--- a/lib/upload/adapters/test.ex
+++ b/lib/upload/adapters/test.ex
@@ -45,6 +45,13 @@ defmodule Upload.Adapters.Test do
     Agent.update(__MODULE__, &Map.put(&1, upload.key, upload))
   end
 
+  @doc """
+  Removes an upload from the state.
+  """
+  def delete_upload(key) do
+    Agent.update(__MODULE__, &Map.delete(&1, key))
+  end
+
   @impl true
   def get_url(key), do: key
 
@@ -56,5 +63,11 @@ defmodule Upload.Adapters.Test do
     upload = %Upload{upload | status: :transferred}
     put_upload(upload)
     {:ok, upload}
+  end
+
+  @impl true
+  def delete(%Upload{key: key}) do
+    delete_upload(key)
+    :ok
   end
 end

--- a/test/upload/adapters/fake_test.exs
+++ b/test/upload/adapters/fake_test.exs
@@ -18,4 +18,8 @@ defmodule Upload.Adapters.FakeTest do
   test "transfer/1" do
     assert {:ok, %Upload{status: :transferred}} = Adapter.transfer(@upload)
   end
+
+  test "delete/1" do
+    assert :ok = Adapter.delete(@upload)
+  end
 end

--- a/test/upload/adapters/local_test.exs
+++ b/test/upload/adapters/local_test.exs
@@ -26,4 +26,11 @@ defmodule Upload.Adapters.LocalTest do
     assert {:ok, %Upload{key: key, status: :transferred}} = Adapter.transfer(@upload)
     assert File.exists?(Path.join(Adapter.storage_path(), key))
   end
+
+  test "delete/1" do
+    assert {:ok, %Upload{key: key, status: :transferred}} = Adapter.transfer(@upload)
+    assert File.exists?(Path.join(Adapter.storage_path(), key))
+    assert :ok = Adapter.delete(@upload)
+    refute File.exists?(Path.join(Adapter.storage_path(), key))
+  end
 end

--- a/test/upload/adapters/s3_test.exs
+++ b/test/upload/adapters/s3_test.exs
@@ -50,4 +50,11 @@ defmodule Upload.Adapters.S3Test do
     assert {:ok, %Upload{key: key, status: :transferred}} = Adapter.transfer(@upload)
     assert {:ok, %{body: "MEATLOAF\n"}} = get_object(key)
   end
+
+  test "delete/1" do
+    assert {:ok, %Upload{key: key, status: :transferred}} = Adapter.transfer(@upload)
+    assert {:ok, %{body: "MEATLOAF\n"}} = get_object(key)
+    assert :ok = Adapter.delete(@upload)
+    assert {:error, _} = get_object(key)
+  end
 end

--- a/test/upload/adapters/test_test.exs
+++ b/test/upload/adapters/test_test.exs
@@ -36,4 +36,11 @@ defmodule Upload.Adapters.TestTest do
   test "get_signed_url/2" do
     assert Adapter.get_signed_url("foo/bar.txt", []) == {:ok, "foo/bar.txt"}
   end
+
+  test "delete/1 removes the upload from the state" do
+    assert Adapter.get_uploads() == %{}
+    assert {:ok, %Upload{key: key}} = Adapter.transfer(@upload)
+    assert :ok = Adapter.delete(@upload)
+    assert %{} == Adapter.get_uploads()
+  end
 end

--- a/test/upload_test.exs
+++ b/test/upload_test.exs
@@ -43,7 +43,8 @@ defmodule UploadTest do
   end
 
   test "generate_key/2" do
-    assert Upload.generate_key("phoenix.png", prefix: ["logos"]) =~ ~r"^logos/[a-z0-9]{32}\.png$"
+    assert Upload.generate_key("phoenix.png", prefix: ["logos"]) =~
+             ~r"^logos/[a-z0-9]{32}\.png$"
   end
 
   test "cast/1 with a %Plug.Upload{}" do


### PR DESCRIPTION
## Problem
Currently we cannot delete files remotely and we need to in some circumstances.

## Solution
- Add a `delete/1` function to the Adapter behavior that takes an Upload and attempts to delete it remotely.
- Implement the `delete/1` function for each adapter.
- Add tests for each adapter.
- Fixed a bug where we were always generating hashed keys for uploads as the default was `nil` which was caught by tests.