### PR TITLE
Simplify `delete/1` to take just a key

### DIFF
--- a/lib/upload.ex
+++ b/lib/upload.ex
@@ -81,8 +81,8 @@ defmodule Upload do
   @doc """
   Deletes the file where it is stored.
   """
-  @spec delete(Upload.t()) :: :ok | {:error, String.t()}
-  def delete(%__MODULE__{} = upload), do: adapter().delete(upload)
+  @spec delete(String.t()) :: :ok | {:error, String.t()}
+  def delete(key), do: adapter().delete(key)
 
   @doc """
   Converts a `Plug.Upload` to an `Upload`.

--- a/lib/upload/adapter.ex
+++ b/lib/upload/adapter.ex
@@ -12,5 +12,5 @@ defmodule Upload.Adapter do
   @callback get_url(String.t()) :: String.t()
   @callback get_signed_url(String.t(), Keyword.t()) :: {:ok, String.t()} | {:error, String.t()}
   @callback transfer(Upload.t()) :: {:ok, Upload.transferred()} | {:error, String.t()}
-  @callback delete(Upload.t()) :: :ok | {:error, String.t()}
+  @callback delete(String.t()) :: :ok | {:error, String.t()}
 end

--- a/lib/upload/adapters/fake.ex
+++ b/lib/upload/adapters/fake.ex
@@ -19,7 +19,7 @@ defmodule Upload.Adapters.Fake do
   end
 
   @impl true
-  def delete(%Upload{} = _upload) do
+  def delete(_key) do
     :ok
   end
 end

--- a/lib/upload/adapters/local.ex
+++ b/lib/upload/adapters/local.ex
@@ -60,7 +60,7 @@ defmodule Upload.Adapters.Local do
   end
 
   @impl true
-  def delete(%Upload{key: key}) do
+  def delete(key) do
     filename = Path.join(storage_path(), key)
 
     case File.rm(filename) do

--- a/lib/upload/adapters/s3.ex
+++ b/lib/upload/adapters/s3.ex
@@ -74,7 +74,7 @@ if Code.ensure_loaded?(ExAws.S3) do
     end
 
     @impl true
-    def delete(%Upload{key: key}) do
+    def delete(key) do
       case delete_object(key) do
         {:ok, _} ->
           :ok

--- a/lib/upload/adapters/test.ex
+++ b/lib/upload/adapters/test.ex
@@ -66,7 +66,7 @@ defmodule Upload.Adapters.Test do
   end
 
   @impl true
-  def delete(%Upload{key: key}) do
+  def delete(key) do
     delete_upload(key)
     :ok
   end

--- a/test/upload/adapters/local_test.exs
+++ b/test/upload/adapters/local_test.exs
@@ -30,7 +30,7 @@ defmodule Upload.Adapters.LocalTest do
   test "delete/1" do
     assert {:ok, %Upload{key: key, status: :transferred}} = Adapter.transfer(@upload)
     assert File.exists?(Path.join(Adapter.storage_path(), key))
-    assert :ok = Adapter.delete(@upload)
+    assert :ok = Adapter.delete(key)
     refute File.exists?(Path.join(Adapter.storage_path(), key))
   end
 end

--- a/test/upload/adapters/s3_test.exs
+++ b/test/upload/adapters/s3_test.exs
@@ -54,7 +54,7 @@ defmodule Upload.Adapters.S3Test do
   test "delete/1" do
     assert {:ok, %Upload{key: key, status: :transferred}} = Adapter.transfer(@upload)
     assert {:ok, %{body: "MEATLOAF\n"}} = get_object(key)
-    assert :ok = Adapter.delete(@upload)
+    assert :ok = Adapter.delete(key)
     assert {:error, _} = get_object(key)
   end
 end

--- a/test/upload/adapters/test_test.exs
+++ b/test/upload/adapters/test_test.exs
@@ -38,9 +38,10 @@ defmodule Upload.Adapters.TestTest do
   end
 
   test "delete/1 removes the upload from the state" do
-    assert Adapter.get_uploads() == %{}
     assert {:ok, %Upload{key: key}} = Adapter.transfer(@upload)
-    assert :ok = Adapter.delete(@upload)
+    refute Adapter.get_uploads() == %{}
+
+    assert :ok = Adapter.delete(key)
     assert %{} == Adapter.get_uploads()
   end
 end


### PR DESCRIPTION
## Problem
After storing an upload all we have is a `key` value. In order to call `delete/1` we need to construct an `Upload{}` struct arbitrarily. 

## Solution
This PR updates the call to `delete/1` to just take a `String.t()` `key`. This simplifies it's usage.

### Before
```elixir
Upload.delete(%Upload{key: key, path: "", filename: ""})
```

### After
```elixir
Upload.delete(key)
```