### PR TITLE
Join prefix paths with path separators

### DIFF
--- a/lib/upload.ex
+++ b/lib/upload.ex
@@ -169,12 +169,12 @@ defmodule Upload do
 
       opts
       |> Keyword.get(:prefix, [])
-      |> Path.join()
+      |> Enum.join("/")
       |> Path.join(uuid <> ext)
     else
       opts
       |> Keyword.get(:prefix, [])
-      |> Path.join()
+      |> Enum.join("/")
       |> Path.join(filename)
     end
   end

--- a/lib/upload.ex
+++ b/lib/upload.ex
@@ -169,10 +169,12 @@ defmodule Upload do
 
       opts
       |> Keyword.get(:prefix, [])
+      |> Path.join()
       |> Path.join(uuid <> ext)
     else
       opts
       |> Keyword.get(:prefix, [])
+      |> Path.join()
       |> Path.join(filename)
     end
   end

--- a/test/upload_test.exs
+++ b/test/upload_test.exs
@@ -47,6 +47,11 @@ defmodule UploadTest do
              ~r"^logos/[a-z0-9]{32}\.png$"
   end
 
+  test "generate_key/2 with multiple prefix elements" do
+    assert Upload.generate_key("phoenix.png", prefix: ["logos", "123"]) =~
+             ~r"^logos/123/[a-z0-9]{32}\.png$"
+  end
+
   test "cast/1 with a %Plug.Upload{}" do
     assert {:ok, upload} = Upload.cast(@plug)
     assert upload.path == @plug.path


### PR DESCRIPTION
When providing a prefix list with multiple elements, they are not joined with path separators.

```elixir
Upload.generate_key("photo.png", prefix: ["logos", "123"], generate_key: false)
> "logos123/photo.png"
```

Expected
```elixir
Upload.generate_key("photo.png", prefix: ["logos", "123"], generate_key: false)
> "logos/123/photo.png"
```

Difference
```diff
+ "logos/123/photo.png"
- "logos123/photo.png"
```