### PR TITLE
Use a GenServer instead of Agents for isolated test process uploads

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.12.2-otp-24
-erlang 24.0.5
+erlang 24.2
+elixir 1.13.2-otp-24

--- a/lib/upload/adapters/test.ex
+++ b/lib/upload/adapters/test.ex
@@ -1,6 +1,5 @@
 defmodule Upload.Adapters.Test do
   use Upload.Adapter
-  use Agent
 
   alias Upload.Adapters.Test.Server
 

--- a/lib/upload/adapters/test/server.ex
+++ b/lib/upload/adapters/test/server.ex
@@ -1,0 +1,59 @@
+defmodule Upload.Adapters.Test.Server do
+  @moduledoc false
+  use GenServer
+  @timeout 30000
+
+  def start_link(_options) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def init(:ok) do
+    {:ok, %{
+      uploads: %{},
+    }}
+  end
+
+  #
+  # Public interface
+  #
+  def put_upload(owner_pid, key, value) do
+    GenServer.call(__MODULE__, {:put_upload, owner_pid, key, value}, @timeout)
+  end
+
+  def get_uploads(owner_pid) do
+    GenServer.call(__MODULE__, {:get_uploads, owner_pid}, @timeout)
+  end
+
+  def delete_upload(owner_pid, key) do
+    GenServer.call(__MODULE__, {:delete_upload, owner_pid, key}, @timeout)
+  end
+
+  #
+  # GenServer callbacks
+  #
+  def handle_call({:put_upload, owner_pid, key, value}, _from, state) do
+    state = if is_nil(state[:uploads][owner_pid]) do
+              put_in(state, [:uploads, owner_pid], %{})
+            else
+              state
+            end
+
+    {:reply, :ok, put_in(state, [:uploads, owner_pid, key], value)}
+  end
+
+  def handle_call({:get_uploads, owner_pid}, _from, state) do
+    {:reply, state[:uploads][owner_pid] || %{}, state}
+  end
+
+  def handle_call({:delete_upload, owner_pid, key}, _from, state) do
+    exists? = not is_nil(state[:uploads][owner_pid][key])
+
+    if exists? do
+      {_discarded_value, state} = pop_in(state, [:uploads, owner_pid, key])
+
+      {:reply, :ok, state}
+    else
+      {:reply, :ok, state}
+    end
+  end
+end

--- a/lib/upload/adapters/test/server.ex
+++ b/lib/upload/adapters/test/server.ex
@@ -8,9 +8,10 @@ defmodule Upload.Adapters.Test.Server do
   end
 
   def init(:ok) do
-    {:ok, %{
-      uploads: %{},
-    }}
+    {:ok,
+     %{
+       uploads: %{}
+     }}
   end
 
   #
@@ -32,11 +33,12 @@ defmodule Upload.Adapters.Test.Server do
   # GenServer callbacks
   #
   def handle_call({:put_upload, owner_pid, key, value}, _from, state) do
-    state = if is_nil(state[:uploads][owner_pid]) do
-              put_in(state, [:uploads, owner_pid], %{})
-            else
-              state
-            end
+    state =
+      if is_nil(state[:uploads][owner_pid]) do
+        put_in(state, [:uploads, owner_pid], %{})
+      else
+        state
+      end
 
     {:reply, :ok, put_in(state, [:uploads, owner_pid, key], value)}
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 {:ok, _} = Application.ensure_all_started(:hackney)
 
+Upload.Adapters.Test.start()
 ExUnit.start()

--- a/test/upload/adapters/test_test.exs
+++ b/test/upload/adapters/test_test.exs
@@ -8,15 +8,6 @@ defmodule Upload.Adapters.TestTest do
   @fixture Path.expand("../../fixtures/text.txt", __DIR__)
   @upload %Upload{path: @fixture, filename: "text.txt", key: "foo/text.txt"}
 
-  setup do
-    {:ok, _} = start_supervised(Upload.Adapters.Test)
-    :ok
-  end
-
-  test "stop/2" do
-    assert :ok = Upload.Adapters.Test.stop()
-  end
-
   test "get_uploads/1 and put_upload/1" do
     assert Adapter.get_uploads() == %{}
     Adapter.put_upload(@upload)

--- a/test/upload/ecto_test.exs
+++ b/test/upload/ecto_test.exs
@@ -33,7 +33,6 @@ defmodule Upload.EctoTest do
   end
 
   setup do
-    assert {:ok, _} = start_supervised(Adapter)
     assert {:ok, upload} = Upload.cast_path(@fixture)
 
     plug_upload = %Plug.Upload{

--- a/test/upload/uploader_test.exs
+++ b/test/upload/uploader_test.exs
@@ -17,11 +17,6 @@ defmodule Upload.UploaderTest do
     end
   end
 
-  setup do
-    {:ok, _} = start_supervised(Upload.Adapters.Test)
-    :ok
-  end
-
   test "delegates by default" do
     assert {:ok, upload} = MyUploader.cast_path("/path/to/foo.png")
     assert {:ok, %Upload{}} = MyUploader.transfer(upload)


### PR DESCRIPTION
## Problem 

Currently we need to make tests non-async and start instances of the test adapter per test to keep our test uploads isolated. This is fine for small parts of the codebase but scaling to multiple schemas exacerbates these issues.

## Solution

Use a GenServer which does book-keeping of processes performing Uploads.

This allows us to remove calls to `start_supervised` and use one GenServer instance for testing, which allows us to remain async safe, as only allowed processes will be able to access their own uploads. Eventually we may want to introduce a global mode like Mox, but for now this should be sufficient.