### PR TITLE
Casting an Upload of the same filename should generate a change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on: [push]
 jobs:
   build:
-    name: Elixir ${{matrix.elixir}}
+    name: Elixir ${{matrix.elixir}} - OTP ${{matrix.otp}}
     runs-on: ubuntu-latest
 
     env:
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         elixir:
-          - "1.8.2"
-          - "1.9.4"
-          - "1.10.4"
-          - "1.11.0"
+          - "1.12.0"
+          - "1.13.0"
+        otp:
+          - "24.3.4"
 
     services:
       fake-s3:
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Elixir
         uses: actions/setup-elixir@v1
         with:
-          otp-version: "22.3.4"
+          otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - name: Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: mix format --check-formatted
 
       - name: Test
-        run: mix coveralls.github
+        run: mix test
 
       - name: Cache dialyzer
         uses: actions/cache@v2

--- a/lib/upload/adapters/test.ex
+++ b/lib/upload/adapters/test.ex
@@ -32,6 +32,13 @@ defmodule Upload.Adapters.Test do
     Server.start_link(nil)
   end
 
+  def child_spec(_) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []}
+    }
+  end
+
   @doc """
   Get all uploads.
   """

--- a/lib/upload/ecto.ex
+++ b/lib/upload/ecto.ex
@@ -95,6 +95,10 @@ if Code.ensure_loaded?(Ecto) do
     def put_upload(changeset, field, %Upload{status: :pending, key: key} = upload, opts) do
       uploader = Keyword.get(opts, :with, Upload)
 
+      # We use `put_in` here as the URL may stay the same but we still want to
+      # generate a change.
+      #
+      # See https://github.com/joydrive/upload/pull/5 for more details.
       changeset
       |> put_in([Access.key(:changes), field], key)
       |> prepare_changes(fn changeset ->

--- a/lib/upload/ecto.ex
+++ b/lib/upload/ecto.ex
@@ -96,7 +96,7 @@ if Code.ensure_loaded?(Ecto) do
       uploader = Keyword.get(opts, :with, Upload)
 
       changeset
-      |> put_change(field, key)
+      |> put_in([Access.key(:changes), field], key)
       |> prepare_changes(fn changeset ->
         case uploader.transfer(upload) do
           {:ok, upload} ->

--- a/test/upload/ecto_test.exs
+++ b/test/upload/ecto_test.exs
@@ -126,7 +126,7 @@ defmodule Upload.EctoTest do
       end
     end
 
-    test "casting an upload of the same filename generates a change", %{
+    test "casting an upload without changing the filename still generates a change", %{
       plug_upload: plug_upload
     } do
       already_uploaded = %Company{logo: "text.txt"}

--- a/test/upload/ecto_test.exs
+++ b/test/upload/ecto_test.exs
@@ -125,6 +125,22 @@ defmodule Upload.EctoTest do
         cast_and_upload("meatloaf", with: BrokenUploader)
       end
     end
+
+    test "casting an upload of the same filename generates a change", %{
+      plug_upload: plug_upload
+    } do
+      already_uploaded = %Company{logo: "text.txt"}
+
+      # This needs to hold for this test to be accurate.
+      assert plug_upload.filename == already_uploaded.logo
+
+      changeset =
+        already_uploaded
+        |> Ecto.Changeset.cast(%{logo: plug_upload}, [])
+        |> Upload.Ecto.cast_upload(:logo, generate_key: false)
+
+      assert changeset.changes.logo == "text.txt"
+    end
   end
 
   describe "cast_upload_path/3" do


### PR DESCRIPTION
## Summary

Currently if an upload is attempted to be cast twice and it has the same filename, it will not be uploaded due to Ecto thinking there is no real change. From Ecto's perspective the column data is the same (The URL) so why should it make a change? This is an edge-case that was not tested for when we adjusted the library to not generate a unique filename on image creation.

## Solution

Always put the change regardless of the filename being the same.