### PR TITLE
Bugfix: Fix key constraint conflict

### DIFF
--- a/lib/upload/blob.ex
+++ b/lib/upload/blob.ex
@@ -96,6 +96,17 @@ defmodule Upload.Blob do
 
   defp add_extension_from_mime(changeset), do: changeset
 
+  def key_with_extension(%__MODULE__{key: key, content_type: content_type})
+      when not is_nil(key) and not is_nil(content_type) do
+    extension = MIME.extensions(content_type) |> List.first()
+
+    if extension do
+      {:ok, key <> "." <> extension}
+    else
+      {:error, "Could not set the extension from the given MIME type: '#{content_type}'"}
+    end
+  end
+
   @doc false
   def change_blob(%Stat{} = stat, key) do
     changeset(

--- a/lib/upload/multi.ex
+++ b/lib/upload/multi.ex
@@ -176,10 +176,10 @@ defmodule Upload.Multi do
     delete_existing_by_key(multi, repo, key_with_extension, existing_assoc?)
   end
 
-  defp delete_existing_by_key(multi, _, _, _existing_assoc? = true), do: multi
+  defp delete_existing_by_key(multi, _, _, true = _existing_assoc?), do: multi
   defp delete_existing_by_key(multi, _, nil, _), do: multi
 
-  defp delete_existing_by_key(multi, repo, key, _existing_assoc? = false) do
+  defp delete_existing_by_key(multi, repo, key, false = _existing_assoc?) do
     existing_blob = repo.get_by(Upload.Blob, key: key)
 
     if existing_blob do

--- a/lib/upload/multi.ex
+++ b/lib/upload/multi.ex
@@ -125,7 +125,7 @@ defmodule Upload.Multi do
   end
 
   defp handle_changeset_changes(repo, changeset, field, record, multi_changes, opts) do
-    key_function = key_function_from_opts(opts)
+    key = key_function_from_opts(opts).(record)
     validate_function = validate_function_from_opts(opts)
 
     case Map.get(changeset.params || %{}, to_string(field), :no_change) do
@@ -137,14 +137,20 @@ defmodule Upload.Multi do
           record
           |> Ecto.Changeset.cast(%{field => new_value}, [])
           |> Upload.Changeset.cast_attachment(field,
-            key_function: fn _ ->
-              key_function.(record)
-            end
+            key_function: fn _ -> key end
           )
           |> validate_function.(field)
 
+        multi =
+          maybe_delete_existing_by_key(
+            Ecto.Multi.new(),
+            repo,
+            record_changeset,
+            field
+          )
+
         record_changeset.changes
-        |> Enum.reduce(Ecto.Multi.new(), fn {changed_field, change}, multi ->
+        |> Enum.reduce(multi, fn {changed_field, change}, multi ->
           # Deletes if the change is 'nil', uploads otherwise.
           handle_change({changed_field, change}, multi, changeset, multi_changes, opts)
         end)
@@ -154,6 +160,32 @@ defmodule Upload.Multi do
           {:ok, result} -> {:ok, result["#{field}_attach_blob"]}
           {:error, _stage, changeset, _rest} -> {:error, changeset}
         end
+    end
+  end
+
+  # If there's an existing blob with the same key, the call to put_assoc for the
+  # blob field will not delete it since it's not associated. This code ensures
+  # that if it's not associated we will delete it with a separate database query
+  # so a foreign key constraint on the key is not raised.
+  defp maybe_delete_existing_by_key(multi, repo, record_changeset, field) do
+    existing_assoc? = not is_nil(Map.get(record_changeset.data, field))
+
+    key_with_extension =
+      Map.get(Ecto.Changeset.get_field(record_changeset, field) || %{}, :key)
+
+    delete_existing_by_key(multi, repo, key_with_extension, existing_assoc?)
+  end
+
+  defp delete_existing_by_key(multi, _, _, _existing_assoc? = true), do: multi
+  defp delete_existing_by_key(multi, _, nil, _), do: multi
+
+  defp delete_existing_by_key(multi, repo, key, _existing_assoc? = false) do
+    existing_blob = repo.get_by(Upload.Blob, key: key)
+
+    if existing_blob do
+      delete_blob(multi, "remove_existing_blob", existing_blob)
+    else
+      multi
     end
   end
 

--- a/lib/upload/multi.ex
+++ b/lib/upload/multi.ex
@@ -108,9 +108,6 @@ defmodule Upload.Multi do
     validating the file format or size of the upload.
   """
   def handle_changes(multi, name, subject, changeset, field, opts \\ []) do
-    key_function = key_function_from_opts(opts)
-    validate_function = validate_function_from_opts(opts)
-
     Multi.run(multi, name, fn repo, changes ->
       # This code is run after the record in inserted in the Multi pipeline.
       # We can use the record ID here to upload the photo.
@@ -123,34 +120,41 @@ defmodule Upload.Multi do
 
       record = repo.preload(record, [field])
 
-      case Map.get(changeset.params || %{}, to_string(field), :no_change) do
-        :no_change ->
-          {:ok, record}
-
-        new_value ->
-          record_changeset =
-            record
-            |> Ecto.Changeset.cast(%{field => new_value}, [])
-            |> Upload.Changeset.cast_attachment(field,
-              key_function: fn _ ->
-                key_function.(record)
-              end
-            )
-            |> validate_function.(field)
-
-          record_changeset.changes
-          |> Enum.reduce(Ecto.Multi.new(), fn {changed_field, change}, multi ->
-            # Deletes if the change is 'nil', uploads otherwise.
-            handle_change({changed_field, change}, multi, changeset, opts)
-          end)
-          |> Multi.update("#{field}_attach_blob", record_changeset)
-          |> repo.transaction()
-          |> case do
-            {:ok, result} -> {:ok, result["#{field}_attach_blob"]}
-            {:error, _stage, changeset, _rest} -> {:error, changeset}
-          end
-      end
+      handle_changeset_changes(repo, changeset, field, record, opts)
     end)
+  end
+
+  defp handle_changeset_changes(repo, changeset, field, record, opts) do
+    key_function = key_function_from_opts(opts)
+    validate_function = validate_function_from_opts(opts)
+
+    case Map.get(changeset.params || %{}, to_string(field), :no_change) do
+      :no_change ->
+        {:ok, record}
+
+      new_value ->
+        record_changeset =
+          record
+          |> Ecto.Changeset.cast(%{field => new_value}, [])
+          |> Upload.Changeset.cast_attachment(field,
+            key_function: fn _ ->
+              key_function.(record)
+            end
+          )
+          |> validate_function.(field)
+
+        record_changeset.changes
+        |> Enum.reduce(Ecto.Multi.new(), fn {changed_field, change}, multi ->
+          # Deletes if the change is 'nil', uploads otherwise.
+          handle_change({changed_field, change}, multi, changeset, opts)
+        end)
+        |> Multi.update("#{field}_attach_blob", record_changeset)
+        |> repo.transaction()
+        |> case do
+          {:ok, result} -> {:ok, result["#{field}_attach_blob"]}
+          {:error, _stage, changeset, _rest} -> {:error, changeset}
+        end
+    end
   end
 
   defp validate_function_from_opts(opts) do

--- a/test/support/person.ex
+++ b/test/support/person.ex
@@ -10,6 +10,6 @@ defmodule Upload.Test.Person do
   end
 
   def changeset(person, attrs \\ %{}) do
-    cast(person, attrs, [])
+    cast(person, attrs, [:avatar_id])
   end
 end

--- a/test/upload/multi_test.exs
+++ b/test/upload/multi_test.exs
@@ -254,7 +254,7 @@ defmodule Upload.MultiTest do
       refute key in list_uploaded_keys()
     end
 
-    test "with an existing blob with the same key, upserts by key" do
+    test "uploads successfully when there is an existing blob with the same key that is disassociated" do
       {:ok, person} = insert_person(%{avatar: @upload})
 
       assert person.avatar != nil


### PR DESCRIPTION
There is an edge case where if a record’s foreign key to the blobs table becomes disassociated and the same record is attempted to be re-uploaded with the same S3 key, a foreign key conflict occurs on the key since the key needs to be unique. The foreign keys shouldn’t be disassociated but it's something that should be allowed and should be handled correctly.